### PR TITLE
Removed in-line style to allow for tighter content security policies.

### DIFF
--- a/jquery.autocomplete.js
+++ b/jquery.autocomplete.js
@@ -77,11 +77,13 @@
           identifier = 'data-identifier="' + this.options.identifier + '"'
       }
       $('<div id="' + this.mainContainerId +
-        '" style="position:absolute;z-index:9999;" ' +
-        'class="autocompleteContainer" ' + identifier + '>' +
+        '" class="autocompleteContainer" ' + identifier + '>' +
         '<div class="autocomplete-w1"><div class="autocomplete" id="' +
-        autocompleteElementId + '" style="display:none; width:300px;"></div></div></div>')
+        autocompleteElementId + '"></div></div></div>')
         .appendTo('body')
+
+      $('#'+this.mainContainerId).css({'position': 'absolute', 'z-index': '9999'})
+      $('#'+autocompleteElementId).css({'display':'none', 'width':'300px'})
 
       this.container = $('#' + autocompleteElementId)
       this.fixPosition()


### PR DESCRIPTION
* Functionally identical but no longer need to use unsafe-inline or hashes
 in content security policies.