### PR TITLE
Altered setOptions to fix a bug.

### DIFF
--- a/jquery.autocomplete.js
+++ b/jquery.autocomplete.js
@@ -106,7 +106,7 @@
       var o = this.options
       $.extend(o, options)
       
-      if (o.lookup) this.setLookup(o.lookup)
+      if (options.lookup) this.setLookup(options.lookup)
       $('#' + this.mainContainerId).css({ zIndex: o.zIndex })
       if (o.identifier) {
          $('#' + this.mainContainerId).attr('data-identifier', o.identifier)


### PR DESCRIPTION
setOptions was not working during testing. The setLookup function was being called repeatedly when the if was set to check o.lookup; this consequently filled the lookup array with objects of the prior array. Setting to options.lookup solves the problem by only running when the options are being set.