### PR TITLE
fixes loydwatkin/jquery.autocomplete#21

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,16 @@
     "mocha": "^2.3.3",
     "connect": "^2.16.1"
   },
+  "license": "MIT",
   "scripts": {
     "test": "./node_modules/.bin/mocha -R spec -t 60000 ./test/test"
   },
-  "version": ">=4.2"
+  "engines": {
+    "node": ">=4.2"
+  },
+  "engineStrict": true,
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/lloydwatkin/jquery.autocomplete"
+  }  
 }


### PR DESCRIPTION
fixes loydwatkin/jquery.autocomplete#14
https://github.com/lloydwatkin/jquery.autocomplete/commit/86c876193883b550913abea3cd519de07900ceea breaks npm install. Correction added.